### PR TITLE
fix requests to webhook

### DIFF
--- a/scenarios/utils/config/configs.go
+++ b/scenarios/utils/config/configs.go
@@ -1,5 +1,11 @@
 package config
 
+// TODO: Add test for build-deploy for a specific commitId.
+// Before user story https://dev.azure.com/Equinor/Radix/_workitems/edit/106471, the AppXCommitId didn't have any effect on the build-deploy jobs
+// To keep consistent behavioru between dev and prod clusters in a transition period until the user story is release to prod
+// we have to use "" as commit Id.
+// When functionality in the user story is released to all clusters, we must add a test to verify that the commit id is actually used by the pipeline job(s)
+
 const (
 	App1Name                         = "canarycicd-test1"
 	App1Repository                   = "https://github.com/equinor/radix-canarycicd-test-1"
@@ -12,7 +18,7 @@ const (
 	App2Owner                        = "a-user@equinor.com"
 	App2Creator                      = "a-user@equinor.com"
 	App2BranchToBuildFrom            = "master"
-	App2CommitID                     = "580f3ae3c0c23503a7cd02a8b60a5dec49279d0f"
+	App2CommitID                     = "" //"580f3ae3c0c23503a7cd02a8b60a5dec49279d0f"
 	App2Repository                   = "https://github.com/equinor/radix-canarycicd-test-2"
 	App2SSHRepository                = "git@github.com:equinor/radix-canarycicd-test-2.git"
 	App2SharedSecret                 = "a sportless strobic spinach"
@@ -28,7 +34,7 @@ const (
 	App3Owner                        = "a-user@equinor.com"
 	App3Creator                      = "a-user@equinor.com"
 	App3BranchToBuildFrom            = "master"
-	App3CommitID                     = "580f3ae3c0c23503a7cd02a8b60a5dec49279d0f"
+	App3CommitID                     = "" // "580f3ae3c0c23503a7cd02a8b60a5dec49279d0f"
 	App3Repository                   = "https://github.com/equinor/radix-canarycicd-test-3"
 	App3SSHRepository                = "git@github.com:equinor/radix-canarycicd-test-3.git"
 	App3SharedSecret                 = "a sportless strobic spinach"
@@ -39,8 +45,8 @@ const (
 	App4Name                         = "canarycicd-test4"
 	App4Repository                   = "https://github.com/equinor/radix-canarycicd-test-4"
 	App4SSHRepository                = "git@github.com:equinor/radix-canarycicd-test-4.git"
-	App4CommitID                     = "02fdd66c44bad6dcbb887186e1a2a2bc9ee075f4"
-	App4NewCommitID                  = "97f71362819b3505087dfe56b5624f88aeebf6cb"
+	App4CommitID                     = "" //"02fdd66c44bad6dcbb887186e1a2a2bc9ee075f4"
+	App4NewCommitID                  = "" //"97f71362819b3505087dfe56b5624f88aeebf6cb"
 	App4SharedSecret                 = "AnySharedSecret"
 	App4Owner                        = "a-user@equinor.com"
 	App4Creator                      = "a-user@equinor.com"

--- a/scenarios/utils/crypto/cryp_utils.go
+++ b/scenarios/utils/crypto/cryp_utils.go
@@ -2,16 +2,16 @@ package crypto
 
 import (
 	"crypto/hmac"
-	"crypto/sha1"
+	"crypto/sha256"
 	"fmt"
 )
 
-// SHA1HMAC computes the GitHub SHA1 HMAC.
-func SHA1HMAC(salt, message []byte) string {
-	// GitHub creates a SHA1 HMAC, where the key is the GitHub secret and the
+// SHA256HMAC computes the GitHub SHA1 HMAC.
+func SHA256HMAC(salt, message []byte) string {
+	// GitHub creates a SHA256 HMAC, where the key is the GitHub secret and the
 	// message is the JSON body.
-	digest := hmac.New(sha1.New, salt)
+	digest := hmac.New(sha256.New, salt)
 	digest.Write(message)
 	sum := digest.Sum(nil)
-	return fmt.Sprintf("sha1=%x", sum)
+	return fmt.Sprintf("sha256=%x", sum)
 }

--- a/scenarios/utils/http/request_utils.go
+++ b/scenarios/utils/http/request_utils.go
@@ -104,7 +104,7 @@ func CheckResponse(resp *http.Response) (bool, error) {
 	}
 
 	if resp.StatusCode >= 200 && resp.StatusCode <= 299 {
-		log.Debug("Response code: 200")
+		log.Debugf("Response code: %d", resp.StatusCode)
 		return true, nil
 	}
 

--- a/scenarios/utils/http/request_utils.go
+++ b/scenarios/utils/http/request_utils.go
@@ -77,7 +77,7 @@ func TriggerWebhookPush(env env.Env, branch, commit, repository, sharedSecret st
 	payload, _ := json.Marshal(parameters)
 
 	req.Header.Add("X-GitHub-Event", "push")
-	req.Header.Add("X-Hub-Signature", crypto.SHA1HMAC([]byte(sharedSecret), payload))
+	req.Header.Add("X-Hub-Signature-256", crypto.SHA256HMAC([]byte(sharedSecret), payload))
 
 	log.Debugf("Trigger webhook push for \"%s\" branch of repository %s, for commit %s", branch, repository, commit)
 
@@ -103,7 +103,7 @@ func CheckResponse(resp *http.Response) (bool, error) {
 		return false, errors.WithMessage(err, "error reading response body")
 	}
 
-	if resp.StatusCode == 200 {
+	if resp.StatusCode >= 200 && resp.StatusCode <= 299 {
 		log.Debug("Response code: 200")
 		return true, nil
 	}


### PR DESCRIPTION
- Use empty commitId to prevent cloning of old radixconfig.yaml. User story [https://dev.azure.com/Equinor/Radix/_workitems/edit/106471](https://dev.azure.com/Equinor/Radix/_workitems/edit/106471) has a task for creating a test in cicd-canary for using specific commit Id in pipeline job
- Use SHA256 as signature algorithm for webhook requests