### PR TITLE
Fix crash-loop with "tls timeout"

### DIFF
--- a/charts/radix-cicd-canary/Chart.yaml
+++ b/charts/radix-cicd-canary/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: radix-cicd-canary
-version: 1.1.9
-appVersion: 1.1.9
+version: 1.1.10
+appVersion: 1.1.10
 kubeVersion: ">=1.22.0"
 description: Radix CICD Canary
 keywords:

--- a/charts/radix-cicd-canary/templates/role.yaml
+++ b/charts/radix-cicd-canary/templates/role.yaml
@@ -34,6 +34,8 @@ rules:
   - update  # required for testing ad-group updates using service account
   - patch   # required for testing ad-group updates using service account
   - delete  # required for testing ad-group updates using service account
+- apiGroups:
+  - ""
   resources:
   - namespaces
   verbs:

--- a/charts/radix-cicd-canary/templates/role.yaml
+++ b/charts/radix-cicd-canary/templates/role.yaml
@@ -21,25 +21,41 @@ rules:
   resources: ["configmaps"]
   verbs: ["get"]
 - apiGroups:
-    - radix.equinor.com
+  - radix.equinor.com
   resources:
-    - radixregistrations
+  - radixregistrations
   resourceNames:
-    - canarycicd-test1
-    - canarycicd-test2
-    - canarycicd-test3
-    - canarycicd-test4
+  - canarycicd-test1
+  - canarycicd-test2
+  - canarycicd-test3
+  - canarycicd-test4
   verbs:
-    - get     # required for testing ad-group updates using service account
-    - update  # required for testing ad-group updates using service account
-    - patch   # required for testing ad-group updates using service account
-    - delete  # required for testing ad-group updates using service account
+  - get     # required for testing ad-group updates using service account
+  - update  # required for testing ad-group updates using service account
+  - patch   # required for testing ad-group updates using service account
+  - delete  # required for testing ad-group updates using service account
 - apiGroups:
-    - ""
+  - radix.equinor.com
   resources:
-    - namespaces
+  - radixregistrations
+  resourceNames:
+  - radix-networkpolicy-canary
   verbs:
-    - list
+  - get     # required for testing ad-group updates using service account
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/radix-cicd-canary/templates/role.yaml
+++ b/charts/radix-cicd-canary/templates/role.yaml
@@ -34,24 +34,6 @@ rules:
   - update  # required for testing ad-group updates using service account
   - patch   # required for testing ad-group updates using service account
   - delete  # required for testing ad-group updates using service account
-- apiGroups:
-  - radix.equinor.com
-  resources:
-  - radixregistrations
-  resourceNames:
-  - radix-networkpolicy-canary
-  verbs:
-  - get     # required for testing NSP-Long
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
   resources:
   - namespaces
   verbs:

--- a/charts/radix-cicd-canary/templates/role.yaml
+++ b/charts/radix-cicd-canary/templates/role.yaml
@@ -41,7 +41,7 @@ rules:
   resourceNames:
   - radix-networkpolicy-canary
   verbs:
-  - get     # required for testing ad-group updates using service account
+  - get     # required for testing NSP-Long
 - apiGroups:
   - batch
   resources:

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/prometheus/client_golang v1.13.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.0
+	k8s.io/api v0.23.9
 	k8s.io/apimachinery v0.23.9
 	k8s.io/client-go v0.23.9
 )
@@ -70,7 +71,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.23.9 // indirect
 	k8s.io/klog/v2 v2.30.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65 // indirect
 	k8s.io/utils v0.0.0-20211116205334-6203023598ed // indirect

--- a/scenarios/utils/defaults/defaults.go
+++ b/scenarios/utils/defaults/defaults.go
@@ -7,8 +7,9 @@ package defaults
 // When functionality in the user story is released to all clusters, we must add a test to verify that the commit id is actually used by the pipeline job(s)
 
 const (
-	App1Name                         = "canarycicd-test1"
-	App1Repository                   = "https://github.com/equinor/radix-canarycicd-test-1"
+	App1Name       = "canarycicd-test1"
+	App1Repository = "https://github.com/equinor/radix-canarycicd-test-1"
+	// file deepcode ignore HardcodedPassword: This is a fake shared secret
 	App1SharedSecret                 = "AnySharedSecret"
 	App1Creator                      = "a-user@equinor.com"
 	App1ConfigBranch                 = "master"

--- a/scenarios/utils/k8sjob/k8sjob_utils.go
+++ b/scenarios/utils/k8sjob/k8sjob_utils.go
@@ -10,10 +10,14 @@ import (
 
 // IsListedWithStatus Checks if job exists with status
 func IsListedWithStatus(cfg config.Config, appName string, appEnv string, jobComponentName string, batchName string, expectedStatus string) error {
+	impersonateUser := cfg.GetImpersonateUser()
+	impersonateGroup := cfg.GetImpersonateGroup()
 	params := jobClient.NewGetBatchesParams().
 		WithJobComponentName(jobComponentName).
 		WithAppName(appName).
-		WithEnvName(appEnv)
+		WithEnvName(appEnv).
+		WithImpersonateUser(&impersonateUser).
+		WithImpersonateGroup(&impersonateGroup)
 
 	clientBearerToken := httpUtils.GetClientBearerToken(cfg)
 	client := httpUtils.GetK8sJobClient(cfg)

--- a/scenarios/utils/k8sjob/k8sjob_utils.go
+++ b/scenarios/utils/k8sjob/k8sjob_utils.go
@@ -10,14 +10,10 @@ import (
 
 // IsListedWithStatus Checks if job exists with status
 func IsListedWithStatus(cfg config.Config, appName string, appEnv string, jobComponentName string, batchName string, expectedStatus string) error {
-	impersonateUser := cfg.GetImpersonateUser()
-	impersonateGroup := cfg.GetImpersonateGroup()
 	params := jobClient.NewGetBatchesParams().
 		WithJobComponentName(jobComponentName).
 		WithAppName(appName).
-		WithEnvName(appEnv).
-		WithImpersonateUser(&impersonateUser).
-		WithImpersonateGroup(&impersonateGroup)
+		WithEnvName(appEnv)
 
 	clientBearerToken := httpUtils.GetClientBearerToken(cfg)
 	client := httpUtils.GetK8sJobClient(cfg)


### PR DESCRIPTION
In prod cluster, radix-cicd-canary crashes quite often with a "tls timeout" when reading the radix-cicd-canary configmap.
We only need to read the configmap when the container starts, which is now done in the init() method.

This won't fix the underlying "tls timeout" error, but at least we reduce the number of calls to the K8S api server, which hopefully reduces the chance of this error occuring in the application